### PR TITLE
Improved hooking points for instrumentors

### DIFF
--- a/lib/the_metal.rb
+++ b/lib/the_metal.rb
@@ -32,4 +32,8 @@ module TheMetal
             end
     Application.new events, chain
   end
+
+  def self.start_app app
+    app.start_app if app.respond_to? :start_app
+  end
 end

--- a/lib/the_metal.rb
+++ b/lib/the_metal.rb
@@ -20,6 +20,10 @@ module TheMetal
     end
   end
 
+  def self.create_server app
+    self.create_server_proxy app
+  end
+
   def self.build_app events, filters, app
     chain = if filters.empty?
               app

--- a/lib/the_metal/puma.rb
+++ b/lib/the_metal/puma.rb
@@ -38,7 +38,7 @@ module TheMetal
     end
   end
 
-  def self.create_server app
+  def self.create_server_proxy app
     Puma::Proxy.new app
   end
 end

--- a/lib/the_metal/puma.rb
+++ b/lib/the_metal/puma.rb
@@ -6,7 +6,7 @@ module TheMetal
   class Puma
     def initialize app
       @app = app
-      app.start_app if app.respond_to? :start_app
+      TheMetal.start_app app
     end
 
     def call env

--- a/lib/the_metal/unicorn.rb
+++ b/lib/the_metal/unicorn.rb
@@ -5,7 +5,7 @@ module TheMetal
   class Unicorn < Unicorn::HttpServer
     def build_app!
       super
-      @app.start_app if @app.respond_to? :start_app
+      TheMetal.start_app @app
     end
 
     def process_client client

--- a/lib/the_metal/unicorn.rb
+++ b/lib/the_metal/unicorn.rb
@@ -37,7 +37,7 @@ module TheMetal
     end
   end
 
-  def self.create_server app
+  def self.create_server_proxy app
     Unicorn::Proxy.new app
   end
 end

--- a/lib/the_metal/webrick.rb
+++ b/lib/the_metal/webrick.rb
@@ -12,6 +12,7 @@ module TheMetal
     class Proxy
       def initialize app
         @app = app
+        TheMetal.start_app app
       end
 
       def listen port, address

--- a/lib/the_metal/webrick.rb
+++ b/lib/the_metal/webrick.rb
@@ -4,7 +4,7 @@ require 'the_metal/request'
 require 'the_metal/response'
 
 module TheMetal
-  def self.create_server app
+  def self.create_server_proxy app
     WEBrick::Proxy.new app
   end
 


### PR DESCRIPTION
Maybe a bit early, but given my day job instrumenting all the things, was curious how things would look in :metal: land.

Rack instrumentation that we added recently at New Relic had the hardest time during startup, so I'm happy to see life looks much better here. This PR smooths over two points that could make my life even easier during startup:
- The primary case around the `create_server` change is the possibility of `require 'the_metal'` happening somewhat distant in load time from the actual specific server implementation. Maybe that's not likely, but if so it's really nice for instrumentors to be able to hook in as soon as any of the machinery is around.
- `start_app` change was just an easy way to get a hook into that point in the lifecycle. Would happily rearrange, but I would :heart: :revolving_hearts: :purple_heart: being able to have that safely exposed where I could get in on it.

It seems like if we could get in at this point in time, getting instrumentation on all the other parts (events, filters, the app itself) is just a matter of dealing properly with each supported form of app that can get passed in.
